### PR TITLE
loading only the required icons

### DIFF
--- a/components/FilterItem.vue
+++ b/components/FilterItem.vue
@@ -86,14 +86,15 @@
         icon
         @click="removeFilter(localFilter.index)"
       >
-        <v-icon>mdi-delete-outline</v-icon>
+        <v-icon>{{ deleteIcon }}</v-icon>
       </v-btn>
     </v-col>
   </v-row>
 </template>
 
 <script>
-// import { mapState, mapGetters, mapActions } from 'vuex'
+import { mdiDeleteOutline } from '@mdi/js'
+
 export default {
   name: 'FiltersItems',
   props: {
@@ -146,6 +147,7 @@ export default {
           (!!parseInt(value) && value >= 0 && value <= 10000) ||
           'Please insert a number between 1 and 10000 rows',
       },
+      deleteIcon: mdiDeleteOutline,
     }
   },
   methods: {

--- a/components/SelectColumns.vue
+++ b/components/SelectColumns.vue
@@ -17,7 +17,7 @@
             :input-value="data.selected"
             :disabled="data.disabled"
             close
-            close-icon="mdi-close"
+            :close-icon="closeIcon"
             @click:close="data.parent.selectItem(data.item)"
           >
             {{ data.item }}
@@ -29,6 +29,7 @@
 </template>
 
 <script>
+import { mdiClose } from '@mdi/js'
 export default {
   props: {
     columns: {
@@ -44,7 +45,11 @@ export default {
       },
     },
   },
-
+  data() {
+    return {
+      closeIcon: mdiClose,
+    }
+  },
   methods: {
     setColumns(columns) {
       this.$emit('updateColumns', columns)

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,15 +2,17 @@
   <v-app dark class="red--text text--lighten-5">
     <v-app-bar :clipped-left="clipped" fixed app class="primary">
       <v-btn icon to="/" router exact>
-        <v-icon>mdi-home</v-icon>
+        <v-icon>{{ homeIcon }}</v-icon>
       </v-btn>
       <v-toolbar-title v-text="title" to="/" />
       <v-spacer />
 
-      <v-btn to="/about" router exact class="ma-1" plain> About </v-btn>
+      <v-btn to="/about" router exact class="ma-1" plain :prefetch="false">
+        About
+      </v-btn>
 
       <v-btn icon href="https://github.com/rajeshdh/sqleditor" target="_blank">
-        <v-icon>mdi-github</v-icon>
+        <v-icon>{{ githubIcon }}</v-icon>
       </v-btn>
     </v-app-bar>
     <v-main>
@@ -26,12 +28,14 @@
 </template>
 
 <script>
+import { mdiGithub, mdiHome } from '@mdi/js'
 export default {
   data() {
     return {
       clipped: false,
-
       fixed: false,
+      homeIcon: mdiHome,
+      githubIcon: mdiGithub,
       title: 'SqlGen - Online SQL Editor',
     }
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -75,8 +75,13 @@ export default {
         },
       },
     },
+    defaultAssets: {
+      icons: false,
+    },
   },
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
-  build: {},
+  build: {
+    extractCSS: true,
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,6 +1629,11 @@
       "resolved": "https://registry.npmjs.org/@lokidb/loki/-/loki-2.1.0.tgz",
       "integrity": "sha512-u2VH/4h4kZww23bak5I/oRai8VqIZCSuqiLbuSHpYXHB9Na5E9KNazh59prgUyvMzfooY7XKiHejbKVxFoAEOQ=="
     },
+    "@mdi/js": {
+      "version": "5.9.55",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-5.9.55.tgz",
+      "integrity": "sha512-BbeHMgeK2/vjdJIRnx12wvQ6s8xAYfvMmEAVsUx9b+7GiQGQ9Za8jpwp17dMKr9CgKRvemlAM4S7S3QOtEbp4A=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     }
   },
   "dependencies": {
+    "@mdi/js": "^5.9.55",
     "@nuxt/content": "^1.14.0",
     "core-js": "^3.9.1",
     "highlight.js": "^10.7.1",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,8 +32,16 @@
           <v-card flat>
             <v-card-text class="d-flex justify-space-between align-center">
               <span class="subtitle-1">FILTERS</span>
-              <v-btn text small outlined color="pink" @click="setFilter">
-                <v-icon>mdi-plus</v-icon>add filter</v-btn
+              <v-btn
+                text
+                small
+                outlined
+                color="pink"
+                :disabled="!selectedColumns.length"
+                @click="setFilter"
+              >
+                <v-icon>{{ plusIcon }}</v-icon
+                >add filter</v-btn
               >
             </v-card-text>
           </v-card>
@@ -118,10 +126,12 @@
 </template>
 
 <script>
+import { mdiPlus } from '@mdi/js'
 import FilterItem from '~/components/FilterItem.vue'
 import Query from '~/components/Query.vue'
 import SelectColumns from '~/components/SelectColumns.vue'
 import SelectTable from '~/components/SelectTable.vue'
+
 export default {
   name: 'Home',
   components: {
@@ -161,6 +171,7 @@ export default {
           text: 'SELECT * FROM customers',
         },
       ],
+      plusIcon: mdiPlus,
     }
   },
   computed: {


### PR DESCRIPTION
This PR adds some performance improvements to decrease page load time. Vuetify uses some default assets, e.g. icons and connects to the cdn to get them.
I replaced them with the **@mdi/js** plugin and only getting the one required for a specific component.